### PR TITLE
Remove force unwrap for webView in Completion

### DIFF
--- a/ios/kamome-framework/src/Completion.swift
+++ b/ios/kamome-framework/src/Completion.swift
@@ -27,7 +27,7 @@ import WebKit
 open class Completion: Completable {
     private let requestID: String
 
-    private weak var webView: WKWebView!
+    private weak var webView: WKWebView?
     private var completed = false
 
     public init(webView: WKWebView, requestID: String) {
@@ -40,9 +40,7 @@ open class Completion: Completable {
     }
 
     public func resolve() {
-        if completed {
-            return
-        }
+        guard !completed, let webView else { return }
 
         completed = true
 
@@ -50,9 +48,7 @@ open class Completion: Completable {
     }
 
     public func resolve(_ data: [String: Any?]) {
-        if completed {
-            return
-        }
+        guard !completed, let webView else { return }
 
         completed = true
 
@@ -60,9 +56,7 @@ open class Completion: Completable {
     }
 
     public func resolve(_ data: [Any?]) {
-        if completed {
-            return
-        }
+        guard !completed, let webView else { return }
 
         completed = true
 
@@ -74,9 +68,7 @@ open class Completion: Completable {
     }
 
     public func reject(_ errorMessage: String?) {
-        if completed {
-            return
-        }
+        guard !completed, let webView else { return }
 
         completed = true
 


### PR DESCRIPTION
In the case of incorrect deinitialization of components in the application, the **Completion** may remain in memory, while the **WebView** will no longer be there. 

As a result, **crashes** will occur when **calling methods** on the **Completion** object. 

Yes, the developer will be at fault here, but the crash will occur in the library. 
I think it’s better if it crashes somewhere in his code rather than inside **kamome** :)"