### PR TITLE
Fix timeoutMillis=0 not disabling request timeout

### DIFF
--- a/js/kamome/src/KM.ts
+++ b/js/kamome/src/KM.ts
@@ -16,7 +16,7 @@ export type CommandHandler = (
 ) => void;
 
 export class WebPlatform {
-  constructor(private handlerDict: { [name: string]: CommandHandler } = {}) { }
+  constructor(private handlerDict: { [name: string]: CommandHandler } = {}) {}
 
   /**
    * Adds a command when it will be processed in the browser not the WebView.

--- a/js/kamome/src/KM.ts
+++ b/js/kamome/src/KM.ts
@@ -16,7 +16,7 @@ export type CommandHandler = (
 ) => void;
 
 export class WebPlatform {
-  constructor(private handlerDict: { [name: string]: CommandHandler } = {}) {}
+  constructor(private handlerDict: { [name: string]: CommandHandler } = {}) { }
 
   /**
    * Adds a command when it will be processed in the browser not the WebView.
@@ -157,7 +157,7 @@ export class KM {
     private receivers: { [commandName: string]: OnReceiver } = {},
     private requests: { [id: string]: KamomeRequest } = {},
     private requestTimeout = 10000,
-  ) {}
+  ) { }
 
   private static instance = new KM();
 
@@ -278,7 +278,7 @@ export class KM {
     data?: KamomeEventData | null,
     timeoutMillis?: number | null,
   ): Promise<KamomeEventResult | null> {
-    const timeout = timeoutMillis || this.instance.requestTimeout;
+    const timeout = timeoutMillis ?? this.instance.requestTimeout;
 
     return new Promise<KamomeEventResult | null>((resolve, reject) => {
       const id = uuid();

--- a/js/kamome/test/KM.test.ts
+++ b/js/kamome/test/KM.test.ts
@@ -236,6 +236,73 @@ describe('KM.send timeout', () => {
     expect(error).toContain('RequestTimeout');
     expect(error).toContain('slowCmd');
   });
+
+  it('should disable timeout when timeoutMillis is 0', async () => {
+    // Reduce the default so the old buggy `||` fallback (treating 0 as falsy)
+    // would fire a short timeout. Under the fix, 0 must disable the timer.
+    KM.setDefaultRequestTimeout(100);
+    try {
+      let resolveHandler: (() => void) | null = null;
+      KM.browser.addCommand('slowCmd', (_data, resolve) => {
+        resolveHandler = () => resolve({ done: true });
+      });
+
+      const sendPromise = KM.send('slowCmd', null, 0);
+
+      // Fire execCommand's setTimeout(0) so the handler captures resolveHandler
+      await vi.advanceTimersByTimeAsync(1);
+      // Well past the (reduced) default timeout — no RequestTimeout must fire
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(resolveHandler).not.toBeNull();
+      resolveHandler!();
+
+      await expect(sendPromise).resolves.toEqual({ done: true });
+    } finally {
+      KM.setDefaultRequestTimeout(10000);
+    }
+  });
+
+  it('should disable timeout when timeoutMillis is negative', async () => {
+    KM.setDefaultRequestTimeout(100);
+    try {
+      let resolveHandler: (() => void) | null = null;
+      KM.browser.addCommand('slowCmd', (_data, resolve) => {
+        resolveHandler = () => resolve({ done: true });
+      });
+
+      const sendPromise = KM.send('slowCmd', null, -1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(resolveHandler).not.toBeNull();
+      resolveHandler!();
+
+      await expect(sendPromise).resolves.toEqual({ done: true });
+    } finally {
+      KM.setDefaultRequestTimeout(10000);
+    }
+  });
+
+  it('should fall back to default timeout when timeoutMillis is null', async () => {
+    KM.setDefaultRequestTimeout(100);
+    try {
+      KM.browser.addCommand('slowCmd', () => {
+        // Intentionally never resolves
+      });
+
+      const promise = KM.send('slowCmd', null, null).catch((e: string) => e);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(200);
+
+      const error = await promise;
+      expect(error).toContain('RequestTimeout');
+    } finally {
+      KM.setDefaultRequestTimeout(10000);
+    }
+  });
 });
 
 describe('WebPlatform', () => {


### PR DESCRIPTION
  - Replace `||` with `??` in `KM.send` so `timeoutMillis = 0` (and other falsy-but-intentional values) are not silently replaced by the default timeout. Matches the documented behavior: "If given `time` <= 0, the request timeout function is disabled."
  - Add regression tests covering `timeoutMillis = 0`, `timeoutMillis = -1`, and the `null` default-fallback path, using a reduced default timeout so the old `||` code path would observably reject while the fixed `??` path resolves.