### PR TITLE
Fix iOS Client memory leak via weak script message handler

### DIFF
--- a/ios/kamome-framework/kamome.xcodeproj/project.pbxproj
+++ b/ios/kamome-framework/kamome.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		5E0D50852BB69F2C00C8CC3A /* Messenger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D50832BB69F2C00C8CC3A /* Messenger.swift */; };
 		5E0D50872BB69FC500C8CC3A /* WaitForReady.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D50862BB69FC500C8CC3A /* WaitForReady.swift */; };
 		5E0D50882BB69FC500C8CC3A /* WaitForReady.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D50862BB69FC500C8CC3A /* WaitForReady.swift */; };
+		5E0D60012BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D60002BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift */; };
+		5E0D60022BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D60002BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift */; };
 		5E0D508A2BB69FF600C8CC3A /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D50892BB69FF600C8CC3A /* Request.swift */; };
 		5E0D508B2BB69FF600C8CC3A /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D50892BB69FF600C8CC3A /* Request.swift */; };
 		5E0D508D2BB6A01D00C8CC3A /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D508C2BB6A01D00C8CC3A /* Completable.swift */; };
@@ -56,6 +58,7 @@
 		5E0D50802BB69E9900C8CC3A /* KamomeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KamomeError.swift; sourceTree = "<group>"; };
 		5E0D50832BB69F2C00C8CC3A /* Messenger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Messenger.swift; sourceTree = "<group>"; };
 		5E0D50862BB69FC500C8CC3A /* WaitForReady.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitForReady.swift; sourceTree = "<group>"; };
+		5E0D60002BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakScriptMessageHandler.swift; sourceTree = "<group>"; };
 		5E0D50892BB69FF600C8CC3A /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		5E0D508C2BB6A01D00C8CC3A /* Completable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completable.swift; sourceTree = "<group>"; };
 		5E0D508F2BB6A03C00C8CC3A /* Completion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completion.swift; sourceTree = "<group>"; };
@@ -124,6 +127,7 @@
 				5E0D50892BB69FF600C8CC3A /* Request.swift */,
 				5E0D50982BB6A1BE00C8CC3A /* TransferData.swift */,
 				5E0D50862BB69FC500C8CC3A /* WaitForReady.swift */,
+				5E0D60002BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -280,6 +284,7 @@
 				5E0D509D2BB6A20E00C8CC3A /* HowToHandleNonExistentCommand.swift in Sources */,
 				5E0D507F2BB69D1300C8CC3A /* ConsoleLogAdapter.swift in Sources */,
 				5E0D50882BB69FC500C8CC3A /* WaitForReady.swift in Sources */,
+				5E0D60022BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift in Sources */,
 				5E0D508E2BB6A01D00C8CC3A /* Completable.swift in Sources */,
 				5E0D50912BB6A03C00C8CC3A /* Completion.swift in Sources */,
 				5E8D4A2A2613254A00BC8771 /* Client.swift in Sources */,
@@ -299,6 +304,7 @@
 				5E0D509C2BB6A20E00C8CC3A /* HowToHandleNonExistentCommand.swift in Sources */,
 				5E0D507E2BB69D1300C8CC3A /* ConsoleLogAdapter.swift in Sources */,
 				5E0D50872BB69FC500C8CC3A /* WaitForReady.swift in Sources */,
+				5E0D60012BB6AA0000C8CC3A /* WeakScriptMessageHandler.swift in Sources */,
 				5E0D508D2BB6A01D00C8CC3A /* Completable.swift in Sources */,
 				5E0D50902BB6A03C00C8CC3A /* Completion.swift in Sources */,
 				5ED97FF824B8BC6600B84867 /* Client.swift in Sources */,

--- a/ios/kamome-framework/src/Client.swift
+++ b/ios/kamome-framework/src/Client.swift
@@ -55,7 +55,13 @@ open class Client: NSObject {
     public init(_ webView: WKWebView) {
         super.init()
         self.webView = webView
-        self.webView!.configuration.userContentController.add(self, name: Self.scriptMessageHandlerName)
+        // Use a weak proxy so WKUserContentController does not retain `self`.
+        // This lets the owner release the Client without having to detach the
+        // script message handler manually.
+        webView.configuration.userContentController.add(
+            WeakScriptMessageHandler(delegate: self),
+            name: Self.scriptMessageHandlerName
+        )
 
         // Add preset commands.
         self.add(Command(Self.commandSYN) { [weak self] _, _, completion in
@@ -68,6 +74,12 @@ open class Client: NSObject {
                 }
                 completion.resolve()
             })
+    }
+
+    deinit {
+        webView?.configuration.userContentController.removeScriptMessageHandler(
+            forName: Self.scriptMessageHandlerName
+        )
     }
 
     /// Adds a command called by the JavaScript code.
@@ -212,7 +224,9 @@ private extension Client {
         let callbackID = "_km_\(commandName)_\(UUID().uuidString)"
 
         // Add a temporary command receiving a result from the JavaScript handler.
-        add(Command(callbackID) { name, data, completion in
+        // Capture `self` weakly to avoid a retain cycle
+        // (commands -> Command -> closure -> Client).
+        add(Command(callbackID) { [weak self] name, data, completion in
             if let data {
                 if let success = data["success"] as? Bool, success {
                     callback?(name, data["result"]!, nil)
@@ -235,7 +249,7 @@ private extension Client {
             completion.resolve()
 
             // Remove the temporary command.
-            self.remove(callbackID)
+            self?.remove(callbackID)
         })
 
         return callbackID

--- a/ios/kamome-framework/src/ConsoleLogAdapter.swift
+++ b/ios/kamome-framework/src/ConsoleLogAdapter.swift
@@ -45,6 +45,13 @@ open class ConsoleLogAdapter: NSObject {
     /// - Parameters:
     ///   - webView: A webView.
     public func setTo(_ webView: WKWebView) {
+        // NOTE: `add(self, name:)` intentionally retains this adapter via the
+        // user content controller so the documented one-liner
+        // `ConsoleLogAdapter().setTo(webView)` keeps the adapter alive for the
+        // lifetime of the WKWebView without the caller having to hold a
+        // reference. Switching to a weak proxy here would deallocate the
+        // adapter immediately after this call returns and stop forwarding
+        // console messages.
         webView.configuration.userContentController.add(self, name: Self.scriptMessageHandlerName)
 
         let jsLog = "window.console.log = function(msg) { window.webkit.messageHandlers.\(Self.scriptMessageHandlerName).postMessage(msg); };"

--- a/ios/kamome-framework/src/WeakScriptMessageHandler.swift
+++ b/ios/kamome-framework/src/WeakScriptMessageHandler.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2026 Hituzi Ando. All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import WebKit
+
+// Breaks the strong reference from `WKUserContentController` to the real handler
+// so the handler owner (e.g. `Client`) can be deallocated without requiring the
+// caller to detach the handler manually.
+final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
+    private weak var delegate: WKScriptMessageHandler?
+
+    init(delegate: WKScriptMessageHandler) {
+        self.delegate = delegate
+        super.init()
+    }
+
+    func userContentController(_ userContentController: WKUserContentController,
+                               didReceive message: WKScriptMessage) {
+        delegate?.userContentController(userContentController, didReceive: message)
+    }
+}


### PR DESCRIPTION
  - Add WeakScriptMessageHandler proxy so WKUserContentController no longer retains Client, letting the owner release it without having to detach the handler manually
  - Register the proxy in Client.init and remove the handler in deinit
  - Capture self weakly in addSendMessageCallback's temporary command closure to break the commands -> Command -> closure -> Client retain cycle
  - Document why ConsoleLogAdapter keeps the direct add(self, name:) registration: the one-liner ConsoleLogAdapter().setTo(webView) pattern relies on userContentController retaining the adapter for the WKWebView lifetime
  - Wire WeakScriptMessageHandler.swift into both Xcode targets