### PR TITLE
Escape dynamic values before embedding them in JavaScript literals

### DIFF
--- a/android/kamome/src/main/java/jp/hituzi/kamome/Messenger.java
+++ b/android/kamome/src/main/java/jp/hituzi/kamome/Messenger.java
@@ -17,14 +17,16 @@ final class Messenger {
     private static final String jsObj = "window.KM";
 
     public static void completeMessage(@NonNull final WebView webView, @Nullable final Object data, @NonNull final String requestId) {
+        final String id = escapeForJSStringLiteral(requestId);
         if (data != null) {
-            runJavaScript(String.format("%s.onComplete(%s, '%s')", jsObj, data, requestId), webView);
+            runJavaScript(String.format("%s.onComplete(%s, '%s')", jsObj, data, id), webView);
         } else {
-            runJavaScript(String.format("%s.onComplete(null, '%s')", jsObj, requestId), webView);
+            runJavaScript(String.format("%s.onComplete(null, '%s')", jsObj, id), webView);
         }
     }
 
     public static void failMessage(@NonNull final WebView webView, @Nullable final String error, @NonNull final String requestId) {
+        final String id = escapeForJSStringLiteral(requestId);
         if (error != null) {
             String errMsg;
             try {
@@ -35,20 +37,50 @@ final class Messenger {
             } catch (UnsupportedEncodingException e) {
                 errMsg = error;
             }
-            runJavaScript(String.format("%s.onError('%s', '%s')", jsObj, errMsg, requestId), webView);
+            runJavaScript(String.format("%s.onError('%s', '%s')", jsObj, errMsg, id), webView);
         } else {
-            runJavaScript(String.format("%s.onError(null, '%s')", jsObj, requestId), webView);
+            runJavaScript(String.format("%s.onError(null, '%s')", jsObj, id), webView);
         }
     }
 
     public static void sendRequest(@NonNull final WebView webView, @NonNull final Request request) {
+        final String name = escapeForJSStringLiteral(request.name);
+        final String callbackId = escapeForJSStringLiteral(request.callbackId);
         if (request.data != null) {
             runJavaScript(String.format("%s.onReceive('%s', %s, '%s')",
-                    jsObj, request.name, request.data, request.callbackId), webView);
+                    jsObj, name, request.data, callbackId), webView);
         } else {
             runJavaScript(String.format("%s.onReceive('%s', null, '%s')",
-                    jsObj, request.name, request.callbackId), webView);
+                    jsObj, name, callbackId), webView);
         }
+    }
+
+    /**
+     * Escapes a string for safe interpolation inside a single-quoted JavaScript string literal.
+     */
+    @NonNull
+    static String escapeForJSStringLiteral(@NonNull final String value) {
+        final StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            switch (c) {
+                case '\\': sb.append("\\\\"); break;
+                case '\'': sb.append("\\'"); break;
+                case '"': sb.append("\\\""); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                case '\u2028': sb.append("\\u2028"); break;
+                case '\u2029': sb.append("\\u2029"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
     }
 
     private static void runJavaScript(@NonNull final String js, @NonNull final WebView webView) {

--- a/android/kamome/src/test/java/jp/hituzi/kamome/MessengerTest.java
+++ b/android/kamome/src/test/java/jp/hituzi/kamome/MessengerTest.java
@@ -1,0 +1,55 @@
+package jp.hituzi.kamome;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessengerTest {
+
+    @Test
+    public void escapesSingleQuotes() {
+        assertEquals("don\\'t", Messenger.escapeForJSStringLiteral("don't"));
+    }
+
+    @Test
+    public void escapesBackslashes() {
+        assertEquals("a\\\\b", Messenger.escapeForJSStringLiteral("a\\b"));
+    }
+
+    @Test
+    public void escapesNewlinesAndTabs() {
+        assertEquals("a\\nb\\rc\\td", Messenger.escapeForJSStringLiteral("a\nb\rc\td"));
+    }
+
+    @Test
+    public void escapesLineSeparator() {
+        assertEquals("a\\u2028b", Messenger.escapeForJSStringLiteral("a\u2028b"));
+    }
+
+    @Test
+    public void escapesParagraphSeparator() {
+        assertEquals("a\\u2029b", Messenger.escapeForJSStringLiteral("a\u2029b"));
+    }
+
+    @Test
+    public void escapesControlCharacters() {
+        assertEquals("\\u0001\\u001f", Messenger.escapeForJSStringLiteral("\u0001\u001f"));
+    }
+
+    @Test
+    public void neutralizesInjectionPayload() {
+        final String malicious = "');alert('xss";
+        assertEquals("\\');alert(\\'xss", Messenger.escapeForJSStringLiteral(malicious));
+    }
+
+    @Test
+    public void leavesSafeCharactersUnchanged() {
+        final String safe = "abcXYZ123_-.~ ";
+        assertEquals(safe, Messenger.escapeForJSStringLiteral(safe));
+    }
+
+    @Test
+    public void emptyStringStaysEmpty() {
+        assertEquals("", Messenger.escapeForJSStringLiteral(""));
+    }
+}

--- a/ios/kamome-framework/src/Messenger.swift
+++ b/ios/kamome-framework/src/Messenger.swift
@@ -28,44 +28,73 @@ class Messenger {
     private static let jsObj = "window.KM"
 
     static func completeMessage(with webView: WKWebView, data: Any?, for requestID: String) throws {
+        let id = escapeForJSStringLiteral(requestID)
         if let data {
             if !JSONSerialization.isValidJSONObject(data) {
                 throw KamomeError.invalidJSONObject
             }
 
             let params = String(data: try JSONSerialization.data(withJSONObject: data), encoding: .utf8)!
-            run(javaScript: "\(jsObj).onComplete(\(params), '\(requestID)')", with: webView)
+            run(javaScript: "\(jsObj).onComplete(\(params), '\(id)')", with: webView)
         }
         else {
-            run(javaScript: "\(jsObj).onComplete(null, '\(requestID)')", with: webView)
+            run(javaScript: "\(jsObj).onComplete(null, '\(id)')", with: webView)
         }
     }
 
     static func failMessage(with webView: WKWebView, error: String?, for requestID: String) {
+        let id = escapeForJSStringLiteral(requestID)
         if let error {
             let allowed = NSCharacterSet.alphanumerics.union(.init(charactersIn: "-._~"))
             let errMsg = error.addingPercentEncoding(withAllowedCharacters: allowed) ?? error
-            run(javaScript: "\(jsObj).onError('\(errMsg)', '\(requestID)')", with: webView)
+            run(javaScript: "\(jsObj).onError('\(errMsg)', '\(id)')", with: webView)
         }
         else {
-            run(javaScript: "\(jsObj).onError(null, '\(requestID)')", with: webView)
+            run(javaScript: "\(jsObj).onError(null, '\(id)')", with: webView)
         }
     }
 
     static func sendRequest(_ request: Request, with webView: WKWebView) throws {
+        let name = escapeForJSStringLiteral(request.name)
+        let callbackID = escapeForJSStringLiteral(request.callbackID)
         if let data = request.data {
             if !JSONSerialization.isValidJSONObject(data) {
                 throw KamomeError.invalidJSONObject
             }
 
             let params = String(data: try JSONSerialization.data(withJSONObject: data), encoding: .utf8)!
-            run(javaScript: "\(jsObj).onReceive('\(request.name)', \(params), '\(request.callbackID)')",
+            run(javaScript: "\(jsObj).onReceive('\(name)', \(params), '\(callbackID)')",
                     with: webView)
         }
         else {
-            run(javaScript: "\(jsObj).onReceive('\(request.name)', null, '\(request.callbackID)')",
+            run(javaScript: "\(jsObj).onReceive('\(name)', null, '\(callbackID)')",
                     with: webView)
         }
+    }
+
+    /// Escapes a string for safe interpolation inside a single-quoted JavaScript string literal.
+    static func escapeForJSStringLiteral(_ value: String) -> String {
+        var result = ""
+        result.reserveCapacity(value.count)
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\\": result += "\\\\"
+            case "'": result += "\\'"
+            case "\"": result += "\\\""
+            case "\n": result += "\\n"
+            case "\r": result += "\\r"
+            case "\t": result += "\\t"
+            case "\u{2028}": result += "\\u2028"
+            case "\u{2029}": result += "\\u2029"
+            default:
+                if scalar.value < 0x20 {
+                    result += String(format: "\\u%04x", scalar.value)
+                } else {
+                    result.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return result
     }
 }
 


### PR DESCRIPTION
Messenger on iOS and Android was string-formatting requestID, request.name, and request.callbackID directly into JavaScript expressions wrapped in single quotes. A command name containing an apostrophe or backslash would break the generated JS and, for attacker-controlled names, could allow arbitrary script execution inside the WebView.

Add escapeForJSStringLiteral helpers that escape the characters that are unsafe inside a single-quoted JS string (backslash, single and double quotes, control characters, LINE/PARAGRAPH SEPARATOR) and route the three dynamic identifiers through them before interpolation. Add Android unit tests covering the escape behavior, including a representative injection payload.