### PR TITLE
Make Client.hasCommand O(1) via dictionary lookup

### DIFF
--- a/ios/kamome-framework/src/Client.swift
+++ b/ios/kamome-framework/src/Client.swift
@@ -104,7 +104,7 @@ open class Client: NSObject {
 
     /// Tells whether specified command is added.
     public func hasCommand(_ name: String) -> Bool {
-        commands.contains { $0.key == name }
+        commands[name] != nil
     }
 
     /// Sends a message to the JavaScript receiver.


### PR DESCRIPTION
hasCommand was scanning the commands dictionary with commands.contains { $0.key == name }, an O(n) walk even though the underlying storage is a hashed [String: Command]. As the number of registered commands grows, every call paid that cost, and hasCommand is hit on every JS->native message via Client.execute.

Replace the contains scan with commands[name] != nil so lookup becomes a single hash probe.