### PR TITLE
Remove force-unwraps around JS-supplied payloads

### DIFF
--- a/android/app/src/main/java/jp/hituzi/kamome/sample/MainActivity.kt
+++ b/android/app/src/main/java/jp/hituzi/kamome/sample/MainActivity.kt
@@ -33,9 +33,14 @@ class MainActivity : Activity() {
             .add(Command("echo") { commandName, data, completion ->
                 // Received `echo` command.
                 // Then sends resolved result to the JavaScript callback function.
-                val map = HashMap<String?, Any?>()
-                map["message"] = data!!.optString("message")
-                completion.resolve(map)
+                val message = data?.optString("message")
+                if (message.isNullOrEmpty()) {
+                    completion.reject("'message' is required")
+                } else {
+                    val map = HashMap<String?, Any?>()
+                    map["message"] = message
+                    completion.resolve(map)
+                }
             })
             .add(Command("echoError") { commandName, data, completion ->
                 // Sends rejected result if failed.

--- a/ios/kamome-framework/src/Client.swift
+++ b/ios/kamome-framework/src/Client.swift
@@ -229,7 +229,12 @@ private extension Client {
         add(Command(callbackID) { [weak self] name, data, completion in
             if let data {
                 if let success = data["success"] as? Bool, success {
-                    callback?(name, data["result"]!, nil)
+                    // `data["result"]` is `Any??` (Dictionary subscript wraps the
+                    // stored Any? in another Optional). `?? nil` flattens a missing
+                    // key to a single-level nil so callers aren't surprised by a
+                    // force-unwrap crash when JS sends `{ success: true }` with no
+                    // `result` key.
+                    callback?(name, data["result"] ?? nil, nil)
                 }
                 else {
                     let reason: String

--- a/ios/kamome-ios-sample/KamomeSwift/ViewController.swift
+++ b/ios/kamome-ios-sample/KamomeSwift/ViewController.swift
@@ -46,7 +46,12 @@ class ViewController: UIViewController {
                 .add(Command("echo") { commandName, data, completion in
                     // Received `echo` command.
                     // Then sends resolved result to the JavaScript callback function.
-                    completion.resolve(["message": data!["message"]!])
+                    if let message = data?["message"] ?? nil {
+                        completion.resolve(["message": message])
+                    }
+                    else {
+                        completion.reject("'message' is required")
+                    }
                 })
                 .add(Command("echoError") { commandName, data, completion in
                     // Sends rejected result if failed.

--- a/ios/kamome-ios-sample/KamomeSwift/ViewController.swift
+++ b/ios/kamome-ios-sample/KamomeSwift/ViewController.swift
@@ -46,12 +46,18 @@ class ViewController: UIViewController {
                 .add(Command("echo") { commandName, data, completion in
                     // Received `echo` command.
                     // Then sends resolved result to the JavaScript callback function.
-                    if let message = data?["message"] ?? nil {
-                        completion.resolve(["message": message])
-                    }
-                    else {
+                    guard let rawMessage = data?["message"] as? String else {
                         completion.reject("'message' is required")
+                        return
                     }
+
+                    let message = rawMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !message.isEmpty else {
+                        completion.reject("'message' is required")
+                        return
+                    }
+
+                    completion.resolve(["message": message])
                 })
                 .add(Command("echoError") { commandName, data, completion in
                     // Sends rejected result if failed.


### PR DESCRIPTION
Three paths force-unwrapped values that JavaScript callers can omit, turning an unexpected payload shape into a hard crash:

- Client.addSendMessageCallback (iOS framework) read data["result"]! on the success branch, so a JS resolve({ success: true }) without a `result` key would trap. Flatten the double-Optional with `?? nil`.
- ViewController echo handler (iOS sample) did completion.resolve(["message": data!["message"]!]); callers copying the sample would inherit the crash. Switch to optional binding and reject with a descriptive reason when `message` is absent.
- MainActivity echo handler (Android sample) did data!!.optString("message"); same exposure. Switch to `data?` and reject with the same reason when the value is missing/empty.