### PR TITLE
Reject unregistered commands in WebPlatform.execCommand

### DIFF
--- a/js/kamome/src/KM.ts
+++ b/js/kamome/src/KM.ts
@@ -114,6 +114,10 @@ export class WebPlatform {
       const reject: CommandHandlerReject = reason => {
         KM.onError(reason ? encodeURIComponent(reason) : null, req.id);
       };
+      if (!this.hasCommand(req.name)) {
+        reject('CommandNotAdded');
+        return;
+      }
       this.handlerDict[req.name](undefinedToNull<KamomeEventData>(req.data), resolve, reject);
     }, 0);
   }

--- a/js/kamome/test/KM.test.ts
+++ b/js/kamome/test/KM.test.ts
@@ -397,8 +397,8 @@ describe('KM pre-ready queue drain (BUG-H01 regression)', () => {
 
 describe('WebPlatform.execCommand missing-command guard (BUG-M01 regression)', () => {
   it('rejects with Rejected:<name>:CommandNotAdded instead of throwing when the command is unregistered', async () => {
-    // Route KM's onError through a capturing receiver so we can observe the
-    // rejection without depending on the global requests map.
+    // Use a direct execCommand request id and observe the propagated rejection
+    // by spying on KM.onError.
     const id = 'direct-exec-' + Date.now();
 
     // Spy on KM.onError to verify the reject reason propagates.

--- a/js/kamome/test/KM.test.ts
+++ b/js/kamome/test/KM.test.ts
@@ -395,6 +395,39 @@ describe('KM pre-ready queue drain (BUG-H01 regression)', () => {
   }, 15000);
 });
 
+describe('WebPlatform.execCommand missing-command guard (BUG-M01 regression)', () => {
+  it('rejects with Rejected:<name>:CommandNotAdded instead of throwing when the command is unregistered', async () => {
+    // Route KM's onError through a capturing receiver so we can observe the
+    // rejection without depending on the global requests map.
+    const id = 'direct-exec-' + Date.now();
+
+    // Spy on KM.onError to verify the reject reason propagates.
+    const spy = vi.spyOn(KM, 'onError');
+
+    try {
+      KM.browser.execCommand({
+        id,
+        name: 'noSuchCommand',
+        data: null,
+        timeout: 0,
+        resolve: () => {},
+        reject: () => {},
+      });
+
+      // execCommand defers the work with setTimeout(0).
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [encodedReason, reqId] = spy.mock.calls[0];
+      expect(reqId).toBe(id);
+      expect(encodedReason).not.toBeNull();
+      expect(decodeURIComponent(encodedReason as string)).toBe('CommandNotAdded');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe('WebPlatform', () => {
   let platform: WebPlatform;
 


### PR DESCRIPTION
execCommand invoked this.handlerDict[req.name] without first verifying the command was registered. The public KM.send path guards this via browser.hasCommand() before calling execCommand, but consumers that call execCommand directly (or any future internal path that skips the pre-check) would hit TypeError: this.handlerDict[req.name] is not a function and leave the request dangling with no reject.

Guard the call inside execCommand so a missing command funnels through the same reject path as a handler-rejected request: encodeURIComponent the reason ("CommandNotAdded") and hand it to KM.onError, which in turn rejects the request promise with Rejected:<name>:CommandNotAdded. Add a regression test that drives execCommand directly with an unregistered name and verifies the reason propagates; the test fails against the previous code with the TypeError.